### PR TITLE
Patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cffi>=1.0.0
 dnspython
 emoji
 gitpython
-google-api-python-client
+google-api-python-client==1.8.0
 google-auth-oauthlib
 googletrans>=2.4.0
 google_images_download>=2.7.1


### PR DESCRIPTION
AttributeError: module 'googleapiclient' has no attribute 'version'  error fix