### PR TITLE
Use correct regex for listening to the command

### DIFF
--- a/userbot/modules/locks.py
+++ b/userbot/modules/locks.py
@@ -10,7 +10,7 @@ from userbot import CMD_HELP
 from userbot.events import register
 
 
-@register(outgoing=True, pattern=r"^.lock ?(.*)")
+@register(outgoing=True, pattern=r"^\.lock ?(.*)")
 async def locks(event):
     input_str = event.pattern_match.group(1).lower()
     peer_id = event.chat_id


### PR DESCRIPTION
With the current syntax
->  .lock ?(.*)
It will listen to any commands like *lockdown* and throw an error - Invalid lock type: donw*